### PR TITLE
Server Option Parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "map-dive",
+  "preferGlobal": false,
+  "main": "server/server.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Instrument/map-dive.git"
+  },
+  "dependencies" : {
+    "socket.io": "0.9.x"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "url": "https://github.com/Instrument/map-dive.git"
   },
   "dependencies" : {
-    "socket.io": "0.9.x"
+    "socket.io": "0.9.x",
+    "commander": "1.x.x"
   }
 }

--- a/server/server.js
+++ b/server/server.js
@@ -1,10 +1,17 @@
 var app = require('http').createServer(handler),
-	io = require('socket.io').listen(app),
-  fs = require('fs'),
   dgram = require("dgram"),
+  fs = require('fs'),
+  io = require('socket.io').listen(app),
+  pg = require('commander'),
   qs = require('querystring');
 
+pg
+  .option( '-p, --port [port]', 'Listen port [8800]', '8086' )
+  .option( '-u, --udp  [port]', 'UDP port [12345]', '12345' )
+  .parse( process.argv );
 
+var listenPort = Number(pg.port);
+var udpPort = Number(pg.udp);
 
 // Used by the level editor, writes a bunch of json into a file.
 function saveLevel(name, json, _cb){
@@ -23,7 +30,7 @@ app.on("listening", function () {
 	var address = app.address();
 	console.log("TCP server listening for displays on " + address.address + ":" + address.port);
 });
-app.listen(8800);
+app.listen(listenPort);
 
 
 // Handler for HTTP requests.
@@ -137,4 +144,4 @@ UDPserver.on("listening", function () {
 	console.log("UDP server listening for user_tracker on " + address.address + ":" + address.port);
 });
 
-UDPserver.bind(12345);
+UDPserver.bind(udpPort);

--- a/server/server.js
+++ b/server/server.js
@@ -6,7 +6,7 @@ var app = require('http').createServer(handler),
   qs = require('querystring');
 
 pg
-  .option( '-p, --port [port]', 'Listen port [8800]', '8086' )
+  .option( '-p, --port [port]', 'Listen port [8800]', '8800' )
   .option( '-u, --udp  [port]', 'UDP port [12345]', '12345' )
   .parse( process.argv );
 


### PR DESCRIPTION
Adding the "commander" node module dependency helps with some option parsing for the server.
Initially implemented are "--port" and "--udp" for the two port settings for server.js.

e.g.: node /path/to/server/server.js --port 8800 --udp 12333
